### PR TITLE
Fix a few typos

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,4 +13,4 @@ We have many projects, but we want to highlight a few, in a quite specific order
 
 ## Work with us
 
-If you choose to contribute to to any our projects, we would love to work with you and help hone your PRs to near perfection. If you like the experience and think you might want to do this full time, we are [always hiring](https://grafana.com/about/careers/).
+If you choose to contribute to any of our projects, we would love to work with you and help hone your PRs to near perfection. If you like the experience and think you might want to do this full-time, we are [always hiring](https://grafana.com/about/careers/).


### PR DESCRIPTION
Fixing three small typos in the Grafana org README. I spotted the `to to` thing and just in case decided to run it all through a grammar check where the other two typos popped up.

Perhaps I could have merged it to the main branch right away, but this is my very first Grafana commit (yay!) as well as my very first commit to someone else's repo on GitHub so I went with a PR. 🙂 