### PR TITLE
docs: recommend bug bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,20 @@
 # Reporting security issues
 
-If you think you have found a security vulnerability, please send a report to [security@grafana.com](mailto:security@grafana.com). This address can be used for all of Grafana Labs's open source and commercial products (including but not limited to Grafana, Grafana Cloud, Grafana Enterprise, and grafana.com). We can accept only vulnerability reports at this address.
+If you think you have found a security vulnerability, please send us a report.
+We accept reports via [our Bug Bounty program][bugbounty] and over email.
+Any of Grafana Labs' open source and commercial products (including but not limited to Grafana, Grafana Cloud, Grafana Enterprise, and grafana.com) are in scope.
+
+## Bug bounty
+
+To submit a bug bounty report, see [our Intigriti program page][bugbounty].
+
+Note that you must create an account on Intigriti to submit a report.
+The program page contains information on what is and is not in scope, as well as the reward structure.
+
+## Email
+
+To send us a report over email, contact us at [security@grafana.com](mailto:security@grafana.com).
+We will only accept vulnerability reports at this address; if you are looking for other security information, please contact our support team on [our website](https://grafana.com).
 
 Please encrypt your message to us; please use our PGP key. The key fingerprint is:
 
@@ -17,3 +31,5 @@ Grafana Labs will send you a response indicating the next steps in handling your
 We will post a summary, remediation, and mitigation details for any patch containing security fixes on the Grafana blog. The security announcement blog posts will be tagged with the [security tag](https://grafana.com/tags/security/).
 
 You can also track security announcements via the [RSS feed](https://grafana.com/tags/security/index.xml).
+
+[bugbounty]: https://app.intigriti.com/programs/grafanalabs/grafanaossbbp/detail


### PR DESCRIPTION
This recommends the bug bounty program.

I've intentionally avoided using words that explicitly say we prefer one over the other, instead relying on people's natural gravitation towards the first presented option, along with spreading the link to the bug bounty program several times over the document to put our foot on the scale a little bit.

The point is to try to get people to use bug bounties, but we still do not want to discredit the email reporting avenue as it is and will remain equally valid, should someone not have access to intigriti, or wish not to use it for any reason.