### PR TITLE
fix: update security report guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,26 @@
 # Reporting security issues
 
 If you think you have found a security vulnerability, please send us a report.
-We prefer reports via [our Bug Bounty program][bugbounty], but also accept reports via email.
+We prefer reports via [our Vulnerability Disclosure Program (VDP)][vdp], but also accept reports via email.
 Any of Grafana Labs' open source and commercial products (including but not limited to Grafana, Grafana Cloud, Grafana Enterprise, and grafana.com) are in scope.
 
-## Bug bounty
+**Important:** We ask you to not disclose the vulnerability before it have been fixed and announced, unless you received a response from the Grafana Labs security team that you can do so.
 
-To submit a bug bounty report, see [our Intigriti program page][bugbounty].
+## Vulnerability disclosure program
+
+To submit a vulnerability report, see [our Intigriti program page][vdp].
 
 Note that you must create an account on Intigriti to submit a report.
-The program page contains information on what is and is not in scope, as well as the reward structure.
-Only reports via Intigriti are eligible for a reward.
+The program page contains information on what is and is not in scope.
+Only reports via Intigriti are eligible for [the Hall of Fame][hall-of-fame].
+Please note that we do not offer bounties for any vulnerability report.
 
 **Important:** We ask you to not disclose the vulnerability before it have been fixed and announced, unless you received a response from the Grafana Labs security team that you can do so.
 
 ## Email
 
-Please note that reports sent over email are not eligible for a reward.
-If you want to be eligible for a reward, please submit your report via our preferred method, [the Bug Bounty program][bugbounty].
+Please note that reports sent over email are not eligible for [the Hall of Fame][hall-of-fame].
+If you want to be eligible for the Hall of Fame, please submit your report via our preferred method, [the VDP][vdp].
 
 To send us a report over email, contact us at [security@grafana.com](mailto:security@grafana.com).
 We will only accept vulnerability reports at this address; if you are looking for other security information, please contact our support team on [our website](https://grafana.com).
@@ -32,10 +35,9 @@ Grafana Labs will send you a response indicating the next steps in handling your
 
 **Important:** We ask you to not disclose the vulnerability before it have been fixed and announced, unless you received a response from the Grafana Labs security team that you can do so.
 
-## Security announcements
+## What should be included in a security report
 
-We will post a summary, remediation, and mitigation details for any patch containing security fixes on the Grafana blog. The security announcement blog posts will be tagged with the [security tag](https://grafana.com/tags/security/).
+We appreciate clear and concise reports that are easy to follow and understand. To do so, provide us with enough information to reproduce the potential vulnerability and address the issue effectively. This may include steps to reproduce the vulnerability, relevant technical details, and any other information that can help us understand the scope and impact of the issue.
 
-You can also track security announcements via the [RSS feed](https://grafana.com/tags/security/index.xml).
-
-[bugbounty]: https://app.intigriti.com/programs/grafanalabs/grafanaossbbp/detail
+[vdp]: https://app.intigriti.com/programs/grafanalabs/grafanalabsvdp/detail
+[hall-of-fame]: ../security/hall-of-fame/_index.md


### PR DESCRIPTION
This updates the guidance on how to report a security vulnerability to us. We've gotten rid of the bug bounty program, and instead use a VDP now. We'll be removing the hall of fame from emails to still retain an incentive in not spamming us over email.

grafana/website: https://github.com/grafana/website/pull/30743